### PR TITLE
Add service layer integration with dummy data and loader

### DIFF
--- a/src/Rentals/Register/Register.actions.ts
+++ b/src/Rentals/Register/Register.actions.ts
@@ -1,3 +1,4 @@
+import { IResposeData } from "../../common/models/common.models";
 import { IFinancialInformation, IFormField, IPersonalInformation } from "./Register.models";
 import { IRegisterService } from "./Register.service";
 
@@ -6,6 +7,7 @@ export enum REGISTER_ACTIONS {
   UPDATE_FINANCIAL_INFO_ENTRY = 'UPDATE_FINANCIAL_INFO_ENTRY', 
   UPDATE_PERSONAL_INFO = 'UPDATE_PERSONAL_INFO',
   UPDATE_FINANCIAL_INFO = 'UPDATE_FINANCIAL_INFO',  
+  UPDATE_API_FLOW = 'UPDATE_API_FLOW',
 }
 
 export type IRegisterDispatchActions = | {
@@ -24,12 +26,19 @@ export type IRegisterDispatchActions = | {
     type: REGISTER_ACTIONS.UPDATE_PERSONAL_INFO;
     data: IPersonalInformation;
 }
+| {
+    type: REGISTER_ACTIONS.UPDATE_API_FLOW;
+    data: {loading?: boolean;
+        errorMessage?: string;};
+}
 
 export interface IRegisterActions {
     updatePersonalInformationEntry:(key: string, value: IFormField) => void;
     updateFinancialInformationEntry:(key: string, value: IFormField) => void;
     updatePersonalInformation:(data: IPersonalInformation) => void;
     updateFinancialInformation:(data: IFinancialInformation) => void;
+    updateAPIFlowState: (loading: boolean) => void;
+    register: (personalInfo: IPersonalInformation, financialInformation: IFinancialInformation) => Promise<void>;
 }
 
 export class RegisterActions implements IRegisterActions {
@@ -39,6 +48,25 @@ export class RegisterActions implements IRegisterActions {
     constructor(dispatch: React.Dispatch<IRegisterDispatchActions>, service: IRegisterService) {
         this.dispatch = dispatch;
         this.service = service;
+    }
+
+    updateAPIFlowState(loading: boolean) {
+        this.dispatch({
+            type: REGISTER_ACTIONS.UPDATE_API_FLOW,
+            data: {loading: loading},
+        });
+    };
+
+    async register(personalInfo: IPersonalInformation, financialInformation: IFinancialInformation): Promise<void> {
+        this.dispatch({
+            type: REGISTER_ACTIONS.UPDATE_API_FLOW,
+            data: { loading: true },
+        });
+        const data = await this.service.register(personalInfo, financialInformation);
+        this.dispatch({
+            type: REGISTER_ACTIONS.UPDATE_API_FLOW,
+            data: { loading: false, errorMessage: data?.errors && data.errors.length > 0 ? data.errors[0] : '' },   
+        });
     }
 
     updatePersonalInformationEntry(key: string, value: IFormField) {

--- a/src/Rentals/Register/Register.models.ts
+++ b/src/Rentals/Register/Register.models.ts
@@ -44,7 +44,6 @@ export interface IFinancialInformation {
 export interface IRegisterState {
     personalInformation: IPersonalInformation;
     financialInformation: IFinancialInformation;
-    isSubmitting: boolean;
-    isSubmitted: boolean;
-    errorMessage: string;
+    loading?: boolean;
+    errorMessage?: string;
 }

--- a/src/Rentals/Register/Register.reducer.ts
+++ b/src/Rentals/Register/Register.reducer.ts
@@ -27,6 +27,9 @@ export const registerReducer = (state: IRegisterState, action: IRegisterDispatch
         case REGISTER_ACTIONS.UPDATE_PERSONAL_INFO: {
             return { ...state,  personalInformation: action.data };
         }
+        case REGISTER_ACTIONS.UPDATE_API_FLOW: {
+            return { ...state, ...action.data };
+        }
         default: {
           throw new Error(`Unhandled action type`);
         }

--- a/src/Rentals/Register/Register.service.ts
+++ b/src/Rentals/Register/Register.service.ts
@@ -1,5 +1,29 @@
+import { IResposeData } from "../../common/models/common.models";
+import { IFinancialInformation, IPersonalInformation } from "./Register.models";
+
 export interface IRegisterService {
+    register(personalInfo: IPersonalInformation, financialInformation: IFinancialInformation): Promise<IResposeData<string>>;
 }
   
 export class RegisterService implements IRegisterService {
+    
+    register(personalInfo: IPersonalInformation, financialInformation: IFinancialInformation): Promise<IResposeData<string>> {
+        return new Promise<string>((resolve) => {
+            setTimeout(() => {
+                resolve('Registration successful');
+            }, 2000); // Simulate a 1-second delay
+        }).then((data: any) => {
+            const responseData: IResposeData<string> = { response: data, errors: [] };
+            return responseData;
+        }).catch((error) => {
+            const responseData: IResposeData<string> = { response: '', errors: [] };
+            if(error?.response?.data?.errors) {
+                responseData.errors = error.response.data.errors;
+            } else {
+                responseData.errors = ['An error occurred while registering'];
+            }
+
+            return responseData;
+        });
+    }
 }

--- a/src/Rentals/Register/Register.styles.ts
+++ b/src/Rentals/Register/Register.styles.ts
@@ -82,7 +82,19 @@ export const RegisterStyles = {
       pb: { xs: 12, sm: 0 },
       mt: { xs: 2, sm: 0 },
       mb: '60px',
-    }
+    },
+    loader: {
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(255, 255, 255, 0.8)',
+      zIndex: 9999,
+  }
 }
 
 export default useStyles;

--- a/src/Rentals/Register/Register.tsx
+++ b/src/Rentals/Register/Register.tsx
@@ -18,6 +18,7 @@ import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded';
 import ChevronLeftRoundedIcon from '@mui/icons-material/ChevronLeftRounded';
 import { useInit } from './Register.hooks';
 import { validateFinancialInformation, validatePersonalInformation } from '../../common/utilities/form-utilities';
+import { CircularProgress } from '@mui/material';
 
 const Register: React.FC = () => {
     const steps = ['Personal Info', 'Financial Info', 'Review'];
@@ -42,7 +43,7 @@ const Register: React.FC = () => {
         setActiveStep((prevActiveStep) => prevActiveStep - 1);
     }
 
-    const handleNext = () => {
+    const handleNext = async () => {
         if(activeStep === 0) {
             const isValidForm = validatePersonalInformation(state.personalInformation);
             if(!isValidForm) {
@@ -55,6 +56,10 @@ const Register: React.FC = () => {
                 actions.updateFinancialInformation(state.financialInformation);
                 return;
             }
+        }
+
+        if(activeStep === 2) {
+            await actions.register(state.personalInformation, state.financialInformation);
         }
 
         setActiveStep((prevActiveStep) => prevActiveStep + 1);
@@ -73,6 +78,11 @@ const Register: React.FC = () => {
     }
 
     return <>
+        {state.loading && (
+            <Box sx={RegisterStyles.loader}>
+                <CircularProgress />
+            </Box>
+        )}
         <Grid container sx={{ height: { xs: '100%', sm: '100dvh' } }}>
           <Grid
             size={{ xs: 12, sm: 5, lg: 4 }}

--- a/src/common/models/common.models.ts
+++ b/src/common/models/common.models.ts
@@ -1,0 +1,5 @@
+export interface IResposeData<T> {
+    response?: T;
+    errors?: string[];
+    loading?: boolean;
+}


### PR DESCRIPTION
- Integrated service layer with dummy data for registration.
- Added a loading spinner to indicate API call progress.
- Centered the spinner in the middle of the screen.
- Disabled the rest of the DOM while the spinner is visible.